### PR TITLE
add Daily Quests section with day filtering, modals, and suggestions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.2.0",
         "axios": "^1.6.7",
+        "date-fns": "^4.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.4.0"
@@ -2137,6 +2138,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -6980,6 +6991,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
+    },
+    "date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.2.0",
     "axios": "^1.6.7",
+    "date-fns": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.4.0"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import SignInForm from "./SignInForm";
 import AddResolutionForm from "./AddResolutionForm";
 // import NavbarTopLoggedIn from "./components/newResopage/NavbarTopLoggedIn";
 import NewResolutions from "./components/newResopage/NewResolutions";
+import DailyQuests from './pages/DailyQuests'; 
 
 const URL = "http://localhost:8000/api/v1/";
 
@@ -35,6 +36,7 @@ function App() {
           <Route path="/signin" element={<SignInForm />} />
           <Route path="/add-resolution" element={<AddResolutionForm />} />
           <Route path="/new-resolutions" element={<NewResolutions />} />
+          <Route path="/daily-quests" element={<DailyQuests />} />
         </Routes>
       </div>
     </Router>

--- a/src/components/QuestModal.jsx
+++ b/src/components/QuestModal.jsx
@@ -1,0 +1,230 @@
+import React, { useState, useRef, useEffect } from "react";
+
+const iconOptions = [
+  "💧",
+  "🧘",
+  "🚶‍♂️",
+  "🥗",
+  "😴",
+  "🏃‍♂️",
+  "📘",
+  "✨",
+  "🤸",
+  "🪥",
+  "🧼",
+  "💪",
+  "🚴",
+  "⏰",
+  "🌱",
+  "📒",
+  "📞",
+  "🍳",
+  "🛏",
+  "✍️",
+];
+const weekDays = [
+  "Mondays",
+  "Tuesdays",
+  "Wednesdays",
+  "Thursdays",
+  "Fridays",
+  "Saturdays",
+  "Sundays",
+];
+
+const QuestModal = ({
+  isOpen,
+  onClose,
+  onSave,
+  onDelete,
+  title,
+  setTitle,
+  frequency,
+  setFrequency,
+  icon,
+  setIcon,
+  isEditing = false,
+}) => {
+  const [showIconPicker, setShowIconPicker] = useState(false);
+  const iconPickerRef = useRef(null);
+  const [repeatDays, setRepeatDays] = useState([]);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (iconPickerRef.current && !iconPickerRef.current.contains(e.target)) {
+        setShowIconPicker(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    setFrequency(
+      repeatDays.includes("Daily") ? "Daily" : repeatDays.join(", "),
+    );
+  }, [repeatDays]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setShowIconPicker(false);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (frequency === "Daily") {
+      setRepeatDays(["Daily"]);
+    } else {
+      setRepeatDays(frequency.split(", ").filter(Boolean));
+    }
+  }, [isOpen]);
+
+  const handleToggleDay = (day) => {
+    if (day === "Daily") {
+      if (repeatDays.includes("Daily")) {
+        setRepeatDays([]);
+      } else {
+        setRepeatDays(["Daily"]);
+      }
+    } else {
+      setRepeatDays((prev) => {
+        let updated = prev.filter((d) => d !== "Daily");
+        return updated.includes(day)
+          ? updated.filter((d) => d !== day)
+          : [...updated, day];
+      });
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      onSave({
+        title,
+        frequency,
+        icon,
+      });
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30">
+      <div
+        className="bg-white rounded-lg p-3 w-full max-w-sm shadow-xl relative"
+        ref={iconPickerRef}
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 text-xl"
+          aria-label="Close"
+        >
+          ×
+        </button>
+
+        <h2 className="text-base font-semibold mb-4 text-center">
+          {isEditing ? "Edit Quest" : "Add Quest"}
+        </h2>
+
+        <div className="mb-2">
+          <label className="block text-xs font-medium mb-1.5">Quest</label>
+          <div
+            className="flex items-center gap-2 w-full border border-gray-300 rounded px-1 py-0 cursor-text hover:bg-gray-50"
+            onClick={() => setShowIconPicker(false)}
+          >
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowIconPicker((prev) => !prev);
+              }}
+              className="text-lg hover:scale-110 transition"
+              title="Choose icon"
+            >
+              {icon || "＋"}
+            </button>
+            <input
+              type="text"
+              className="flex-1 focus:outline-none bg-transparent text-gray-800 text-xs"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Enter quest name"
+              onKeyDown={handleKeyDown}
+            />
+          </div>
+
+          <div
+            className={`mt-2 flex flex-wrap gap-2 p-2 bg-gray-50 rounded transition-all duration-300 ease-in-out ${
+              showIconPicker
+                ? "opacity-100 max-h-[200px]"
+                : "opacity-0 max-h-0 overflow-hidden"
+            }`}
+          >
+            {iconOptions.map((option) => (
+              <button
+                key={option}
+                onClick={() => {
+                  setIcon(option);
+                  setShowIconPicker(false);
+                }}
+                className={`text-lg hover:scale-110 transition ${
+                  icon === option ? "ring-2 ring-blue-400 rounded" : ""
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="mb-2">
+          <label className="block text-xs font-medium mb-1.5">
+            Repeat Frequency
+          </label>
+          <div className="flex flex-col gap-2">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                className="accent-[#3c51e0] w-3 h-3"
+                checked={repeatDays.includes("Daily")}
+                onChange={() => handleToggleDay("Daily")}
+              />
+              <span className="text-xs">Daily</span>
+            </label>
+            {weekDays.map((day) => (
+              <label key={day} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="w-3 h-3"
+                  checked={repeatDays.includes(day)}
+                  onChange={() => handleToggleDay(day)}
+                />
+                <span className="text-xs">{day}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3 mt-6">
+          {isEditing && (
+            <button
+              onClick={onDelete}
+              className="px-2.5 py-1 rounded-full border border-red-300 text-red-600 hover:bg-red-50 text-xs"
+            >
+              Delete
+            </button>
+          )}
+          <button
+            onClick={() => onSave({ title, frequency, icon })}
+            className="px-2.5 py-1 bg-[#3c51e0] text-white rounded-full hover:bg-blue-700 text-xs"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuestModal;

--- a/src/pages/DailyQuests.jsx
+++ b/src/pages/DailyQuests.jsx
@@ -38,7 +38,7 @@ const DailyQuests = () => {
           id: 3,
           title: "Read 1 page",
           icon: "📘",
-          frequency: "Tuesdays, Thursdays, Sundays",
+          frequency: "Daily",
           completed: {},
         },
         {

--- a/src/pages/DailyQuests.jsx
+++ b/src/pages/DailyQuests.jsx
@@ -1,0 +1,368 @@
+import React, { useEffect, useState } from "react";
+import { format, addDays } from "date-fns";
+import QuestModal from "../components/QuestModal";
+import NavbarTopLoggedIn from "../components/newResopage/NavbarTopLoggedIn";
+
+const daysOfWeek = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+
+const DailyQuests = () => {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [selectedDay, setSelectedDay] = useState(currentDate);
+  const [quests, setQuests] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const [showModal, setShowModal] = useState(false);
+  const [selectedQuest, setSelectedQuest] = useState(null);
+  const [title, setTitle] = useState("");
+  const [frequency, setFrequency] = useState("Daily");
+  const [icon, setIcon] = useState("+");
+
+  useEffect(() => {
+    setTimeout(() => {
+      setQuests([
+        {
+          id: 1,
+          title: "Drink water",
+          icon: "💧",
+          frequency: "Daily",
+          completed: {},
+        },
+        {
+          id: 2,
+          title: "Stretch",
+          icon: "🤸",
+          frequency: "Mondays, Wednesdays",
+          completed: {},
+        },
+        {
+          id: 3,
+          title: "Read a book",
+          icon: "📘",
+          frequency: "Tuesdays, Thursdays, Sundays",
+          completed: {},
+        },
+        {
+          id: 4,
+          title: "Meditate for 10 minutes",
+          icon: "✨",
+          frequency: "Daily",
+          completed: {},
+        },
+        {
+          id: 5,
+          title: "Go for a walk",
+          icon: "🚶‍♂️",
+          frequency: "Fridays",
+          completed: {},
+        },
+        {
+          id: 6,
+          title: "Sleep early",
+          icon: "🛏",
+          frequency: "Mondays, Wednesdays, Fridays",
+          completed: {},
+        },
+        {
+          id: 7,
+          title: "Write journal entry",
+          icon: "✍️",
+          frequency: "Fridays",
+          completed: {},
+        },
+      ]);
+      setLoading(false);
+    }, 500);
+  }, []);
+
+  const handleToggle = (questId) => {
+    const dateKey = format(selectedDay, "yyyy-MM-dd");
+    setQuests((prev) =>
+      prev.map((q) =>
+        q.id === questId
+          ? {
+              ...q,
+              completed: {
+                ...(q.completed || {}),
+                [dateKey]: !q.completed?.[dateKey],
+              },
+            }
+          : q,
+      ),
+    );
+  };
+
+  const resetModalState = (quest = null) => {
+    setSelectedQuest(quest);
+    setTitle(quest?.title || "");
+    setFrequency(quest?.frequency || "Daily");
+    setIcon(quest?.icon || "?");
+    setShowModal(true);
+  };
+
+  const handleAddQuest = () => resetModalState();
+
+  const openEditModal = (quest) => resetModalState(quest);
+
+  const changeWeek = (direction) => {
+    setCurrentDate((prev) => addDays(prev, direction === "next" ? 7 : -7));
+  };
+
+  const weekDays = Array.from({ length: 7 }, (_, index) => {
+    const day = addDays(currentDate, index - currentDate.getDay());
+    return {
+      fullDate: day,
+      date: day.getDate(),
+      day: daysOfWeek[day.getDay()],
+    };
+  });
+
+  const [suggestions, setSuggestions] = useState([
+    { title: "Do yoga", icon: "🧘", frequency: "Mondays, Wednesdays, Fridays" },
+    { title: "Eat a healthy meal", icon: "🥗", frequency: "Daily" },
+    { title: "Call a friend", icon: "📞", frequency: "Saturdays" },
+    { title: "Write gratitude journal", icon: "📒", frequency: "Sundays" },
+  ]);
+
+  const handleSave = (updatedQuest) => {
+    if (selectedQuest) {
+      setQuests((prev) =>
+        prev.map((q) => (q.id === selectedQuest.id ? updatedQuest : q)),
+      );
+    } else {
+      setQuests((prev) => [
+        ...prev,
+        { ...updatedQuest, id: Date.now(), completed: {} },
+      ]);
+    }
+    setShowModal(false);
+  };
+
+  const handleDelete = () => {
+    if (selectedQuest) {
+      setQuests((prev) => prev.filter((q) => q.id !== selectedQuest.id));
+      setShowModal(false);
+    }
+  };
+
+  return (
+    <div className="bg-[#EDEDF4] min-h-screen">
+      <NavbarTopLoggedIn />
+
+      <div className="p-6 max-w-xs mx-auto">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-1">Daily Quests</h1>
+          <p className="text-black font-semibold text-sm mb-4 mt-2">
+            {format(selectedDay, "EEEE, MMMM d")}
+          </p>
+        </div>
+
+        <div className="flex items-center justify-center gap-2 mb-6">
+          <button
+            onClick={() => changeWeek("prev")}
+            className="text-gray-500 text-3xl -ml-4"
+          >
+            ‹
+          </button>
+          <div className="flex overflow-x-auto scroll-snap-type-x">
+            {weekDays.map(({ date, day, fullDate }) => (
+              <button
+                key={day}
+                onClick={() => setSelectedDay(fullDate)}
+                className={`flex flex-col items-center w-10 px-1.5 py-1.5 rounded-xl text-xs mx-0.5 ${
+                  selectedDay.getDate() === date
+                    ? "bg-[#3c51e0] text-white"
+                    : "bg-white text-[gray-800] hover:bg-[#3c51e0]/10"
+                } scroll-snap-start shadow-sm border border-gray-200`}
+              >
+                <span>{date}</span>
+                <span className="text-[8px] text-gray-400">{day}</span>
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={() => changeWeek("next")}
+            className="text-gray-500 text-3xl -mr-4"
+          >
+            ›
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="text-center text-gray-500 italic">
+            Loading daily quests...
+          </div>
+        ) : (
+          <>
+            {quests.length === 0 ? (
+              <p className="text-gray-400 italic mt-4">
+                No quests for today yet. Add one!
+              </p>
+            ) : (
+              <ul className="space-y-1.5">
+                {[...quests]
+                  .filter((q) => {
+                    if (!q.frequency) return false;
+
+                    const selectedDayName = format(
+                      selectedDay,
+                      "EEEE",
+                    ).toLowerCase();
+
+                    const freqDays = q.frequency
+                      .toLowerCase()
+                      .split(/,\s*/)
+                      .map((day) => day.replace(/s$/, ""));
+
+                    return (
+                      q.frequency.toLowerCase() === "daily" ||
+                      freqDays.includes(selectedDayName.replace(/s$/, ""))
+                    );
+                  })
+                  .sort((a, b) => {
+                    const aIsDaily = a.frequency === "Daily";
+                    const bIsDaily = b.frequency === "Daily";
+                    return aIsDaily === bIsDaily ? 0 : aIsDaily ? -1 : 1;
+                  })
+                  .map((quest) => (
+                    <li
+                      key={quest.id}
+                      className="flex justify-between items-center p-2 rounded-xl border border-gray-200 shadow-sm bg-white"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-lg">{quest.icon}</span>
+                        <div className="flex flex-col">
+                          <span
+                            className={`text-xs font-medium ${
+                              quest.completed?.[
+                                format(selectedDay, "yyyy-MM-dd")
+                              ]
+                                ? "line-through text-gray-400"
+                                : "text-black"
+                            }`}
+                          >
+                            {quest.title}
+                          </span>
+                          <span className="text-[10px] text-gray-400">
+                            {quest.frequency}
+                          </span>
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => handleToggle(quest.id)}
+                          className={`w-5 h-5 flex items-center justify-center rounded-[6px] border-2 transition-colors ${
+                            quest.completed?.[format(selectedDay, "yyyy-MM-dd")]
+                              ? "bg-[#3c50e0] border-[#3c50e0] text-white"
+                              : "border-[#3c50e0] text-transparent"
+                          }`}
+                        >
+                          {quest.completed?.[
+                            format(selectedDay, "yyyy-MM-dd")
+                          ] ? (
+                            <svg
+                              className="w-3 h-3"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="3"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M5 13l4 4L19 7"
+                              />
+                            </svg>
+                          ) : (
+                            <span className="w-3 h-3" />
+                          )}
+                        </button>
+
+                        <button
+                          onClick={() => openEditModal(quest)}
+                          className="text-gray-500 hover:text-gray-700 text-xl font-bold"
+                          title="Edit"
+                        >
+                          ⋮
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+              </ul>
+            )}
+          </>
+        )}
+
+        <button
+          onClick={handleAddQuest}
+          className="mt-2 w-full flex items-center gap-2 px-3 py-3 bg-[#D3D4DC] rounded-xl shadow-sm"
+        >
+          <span className="w-5 h-5 flex items-center justify-center rounded-[6px] bg-[#EFEFEF] text-[#757575] text-sm font-bold leading-none">
+            +
+          </span>
+          <span className="text-xs text-gray-800">Add a daily quest</span>
+        </button>
+
+        <QuestModal
+          isOpen={showModal}
+          onClose={() => setShowModal(false)}
+          onSave={handleSave}
+          onDelete={handleDelete}
+          title={title}
+          setTitle={setTitle}
+          frequency={frequency}
+          setFrequency={setFrequency}
+          icon={icon}
+          setIcon={setIcon}
+          isEditing={!!selectedQuest}
+        />
+
+        <div className="mt-8">
+          <h2 className="text-md font-semibold text-gray-700 mb-2">
+            Suggestions
+          </h2>
+          <ul className="space-y-1.5">
+            {suggestions.map((s, index) => (
+              <li
+                key={index}
+                className="flex justify-between items-center p-2 rounded-xl border border-gray-200 shadow-sm bg-white"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-lg">{s.icon}</span>
+                  <div className="flex flex-col">
+                    <span className="text-xs font-medium text-gray-800">
+                      {s.title}
+                    </span>
+                    <span className="text-[10px] text-gray-400">
+                      {s.frequency}
+                    </span>
+                  </div>
+                </div>
+                <button
+                  onClick={() => {
+                    const newQuest = {
+                      id: Date.now(),
+                      title: s.title,
+                      icon: s.icon,
+                      frequency: s.frequency,
+                      completed: {},
+                    };
+                    setQuests((prev) => [...prev, newQuest]);
+                    setSuggestions((prev) =>
+                      prev.filter((_, i) => i !== index),
+                    );
+                  }}
+                  className="w-5 h-5 flex items-center justify-center rounded-[6px] border-2 border-[#3c50e0] bg-[#3c50e0] text-white hover:bg-white hover:text-[#3c50e0] transition-colors leading-none pb-[2px]"
+                >
+                  <span className="text-sm font-bold leading-none">+</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DailyQuests;

--- a/src/pages/DailyQuests.jsx
+++ b/src/pages/DailyQuests.jsx
@@ -36,7 +36,7 @@ const DailyQuests = () => {
         },
         {
           id: 3,
-          title: "Read a book",
+          title: "Read 1 page",
           icon: "📘",
           frequency: "Tuesdays, Thursdays, Sundays",
           completed: {},


### PR DESCRIPTION
## Description

_1) What does this PR do? 

This PR adds the DailyQuests page, allowing users to view, create, and edit daily and weekly quests.  

2) List out what you did._

- Created `DailyQuests.jsx` with layout and quest list  
- Implemented quest modal for adding/editing quests  
- Set up filtering logic based on frequency (e.g. "Mondays", "Fridays", "Daily")  
- Added styling for selected day, toggle, and quest completion  
- Enabled suggestion-based quest creation  

## Jira Related Issue

N/A

## Type of Changes

_Feature update

## Acceptance Criteria

- Users can view quests for selected day  
- Users can add/edit quests via modal  
- Frequency is respected in daily filtering  
- New quests show up immediately  
- Completed quests toggle works

## Update Screenshots

<img width="1425" alt="Daily Quests" src="https://github.com/user-attachments/assets/62c75fd4-915b-40de-b808-54d04e821e98" />
<img width="388" alt="Modal" src="https://github.com/user-attachments/assets/17d84c60-d4cb-4388-9669-da6ab7c35153" />

## Testing Instructions

1.	Run the app locally using npm run dev.
2.	Navigate to the /daily-quests route.
3.	Add a new quest (e.g., one for “Wednesdays”) using the “Add a daily quest” button.
4.	Switch between days of the week in the UI and check that quests are correctly filtered.
5.	Edit an existing quest and confirm that the updates are saved and displayed.
6.	Click the + button on a suggested quest and verify that it appears in the list immediately.
	
## Learnings (Optional)

_Document any things you learned or 'gotchas' you experienced._
